### PR TITLE
Fix for Visual Studio 2015

### DIFF
--- a/cocos2d-x/PhysicsShapeCache.cpp
+++ b/cocos2d-x/PhysicsShapeCache.cpp
@@ -110,7 +110,7 @@ bool PhysicsShapeCache::addShapesWithFile(const std::string &plist, float scaleF
                 const ValueVector &polygonsArray = fixturedata.at("polygons").asValueVector();
                 for (auto &polygonitem : polygonsArray)
                 {
-                    Polygon *poly = new Polygon();
+                    class Polygon *poly = new class Polygon();
                     fd->polygons.pushBack(poly);
                     auto &polygonArray = polygonitem.asValueVector();
                     poly->numVertices = (int)polygonArray.size();

--- a/cocos2d-x/PhysicsShapeCache.cpp
+++ b/cocos2d-x/PhysicsShapeCache.cpp
@@ -182,7 +182,8 @@ PhysicsBody *PhysicsShapeCache::createBodyWithName(const std::string &name)
     BodyDef *bd = getBodyDef(name);
     if (!bd)
     {
-        return 0; // body not found
+        CCLOG("WARNING: PhysicsBody with name \"%s\", not found!", name.c_str());
+        return nullptr;
     }
     PhysicsBody *body = PhysicsBody::create();
     setBodyProperties(body, bd);

--- a/cocos2d-x/PhysicsShapeCache.h
+++ b/cocos2d-x/PhysicsShapeCache.h
@@ -97,7 +97,7 @@ class FixtureData : public Ref
     float radius;
 
     // for polygons / polyline
-    Vector<Polygon *> polygons;
+    Vector<class Polygon*> polygons;
 };
 
 


### PR DESCRIPTION
Compiling the PhysicsEditor loader for Cocos2D-X on Visual Studio 2015 generates compiler error [C2059](https://msdn.microsoft.com/en-us/library/t8xe60cf.aspx) and [C2065](https://msdn.microsoft.com/en-us/library/ewcf0002.aspx). This pull request fixes these issues.

Other Platforms tested: Linux GCC 6.1.1, Android NDK r12b
