### PR TITLE
Fixed memory leaks

### DIFF
--- a/cocos2d-x/PhysicsShapeCache.h
+++ b/cocos2d-x/PhysicsShapeCache.h
@@ -108,7 +108,7 @@ private:
     } FixtureType;
 
 
-    class Polygon : public Ref
+    class Polygon
     {
     public:
         Point* vertices;
@@ -116,7 +116,7 @@ private:
     };
 
 
-    class FixtureData : public Ref
+    class FixtureData
     {
     public:
         FixtureType fixtureType;
@@ -140,7 +140,7 @@ private:
     };
 
 
-    class BodyDef : public Ref
+    class BodyDef
     {
     public:
         Point anchorPoint;

--- a/cocos2d-x/PhysicsShapeCache.h
+++ b/cocos2d-x/PhysicsShapeCache.h
@@ -37,14 +37,14 @@ USING_NS_CC;
 class PhysicsShapeCache
 {
 public:
-    
+
     /**
      * Get pointer to the PhysicsShapeCache singleton instance
      *
      * @return PhysicsShapeCache*
      */
     static PhysicsShapeCache *getInstance();
-    
+
     /**
      * Adds all physics shapes from a plist file.
      * Shapes are scaled by contentScaleFactor
@@ -66,32 +66,32 @@ public:
      * @retval false on error
      */
     bool addShapesWithFile(const std::string &plist, float scaleFactor);
-    
+
     /**
-     * Removes all shapes loaded from the given file 
-     * 
+     * Removes all shapes loaded from the given file
+     *
      * @param plist name of the body definitions file
      */
     void removeShapesWithFile(const std::string &plist);
-    
+
     /**
      * Removes all shapes
      */
     void removeAllShapes();
-    
+
     /**
      * Creates a PhysicsBody with the given name
-     * 
+     *
      * @param name name of the body to create
      *
      * @return new PhysicsBody
      * @retval nullptr if body is not found
      */
     PhysicsBody *createBodyWithName(const std::string &name);
-    
+
     /**
      * Creates a new PhysicsBody and attaches it to the given sprite
-     * 
+     *
      * @param name name of the body to attach
      * @param sprite sprite to attach the body to
      *
@@ -99,57 +99,57 @@ public:
      * @retval false if body was not found
      */
     bool setBodyOnSprite(const std::string &name, Sprite *sprite);
-    
+
 private:
     typedef enum
     {
         FIXTURE_POLYGON,
         FIXTURE_CIRCLE
     } FixtureType;
-    
-    
+
+
     class Polygon : public Ref
     {
     public:
         Point* vertices;
         int numVertices;
     };
-    
-    
+
+
     class FixtureData : public Ref
     {
     public:
         FixtureType fixtureType;
-        
+
         float density;
         float restitution;
         float friction;
-        
+
         int tag;
         int group;
         int categoryMask;
         int collisionMask;
         int contactTestMask;
-        
+
         // for circles
         Point center;
         float radius;
-        
-        // for polygons / polyline
-        Vector<Polygon *> polygons;
+
+
+        std::vector<Polygon *> polygons;
     };
-    
-    
+
+
     class BodyDef : public Ref
     {
     public:
         Point anchorPoint;
-        Vector<FixtureData *> fixtures;
-        
+        std::vector<FixtureData *> fixtures;
+
         bool isDynamic;
         bool affectedByGravity;
         bool allowsRotation;
-        
+
         float linearDamping;
         float angularDamping;
         float velocityLimit;
@@ -162,9 +162,9 @@ private:
     BodyDef *getBodyDef(const std::string &name);
     void setBodyProperties(PhysicsBody *body, BodyDef *bd);
     void setShapeProperties(PhysicsShape *shape, FixtureData *fd);
-    
-    Map<std::string, BodyDef *> bodyDefs;
-    std::map<std::string, std::vector<BodyDef *> > bodiesInFile;
+
+    std::map<std::string, BodyDef *> bodyDefs;
+    std::map<std::string, std::vector<BodyDef *>> bodiesInFile;
 };
 
 


### PR DESCRIPTION
Currently valgrind is reporting a memory leak when loading bodies from file:

````
==11949== LEAK SUMMARY:
==11949==    definitely lost: 288 bytes in 3 blocks
==11949==    indirectly lost: 488 bytes in 10 blocks
==11949==      possibly lost: 1,352 bytes in 18 blocks
==11949==    still reachable: 112,392 bytes in 983 blocks
==11949==                       of which reachable via heuristic:
==11949==                         newarray           : 1,536 bytes in 16 blocks
==11949==         suppressed: 0 bytes in 0 blocks
````

There's also no need to use cocos2d::Vector, nor cocos2d::Map. Using std::vector and std::map is enough. Unnecessary whitespace was also removed.

Here's the final valgrind report after this change which is normal for an empty cocos2d-x project:

````
==13917== LEAK SUMMARY:
==13917==    definitely lost: 0 bytes in 0 blocks
==13917==    indirectly lost: 0 bytes in 0 blocks
==13917==      possibly lost: 1,352 bytes in 18 blocks
==13917==    still reachable: 112,392 bytes in 983 blocks
````