### PR TITLE
Use std::unordered_map instead of std::map

### DIFF
--- a/cocos2d-x/PhysicsShapeCache.h
+++ b/cocos2d-x/PhysicsShapeCache.h
@@ -163,8 +163,8 @@ private:
     void setBodyProperties(PhysicsBody *body, BodyDef *bd);
     void setShapeProperties(PhysicsShape *shape, FixtureData *fd);
 
-    std::map<std::string, BodyDef *> bodyDefs;
-    std::map<std::string, std::vector<BodyDef *>> bodiesInFile;
+    std::unordered_map<std::string, BodyDef *> bodyDefs;
+    std::unordered_map<std::string, std::vector<BodyDef *>> bodiesInFile;
 };
 
 


### PR DESCRIPTION
I inspected the code again and I think it's better to use `std::unordered_map` for `bodyDefs` and `bodiesInFile` instead since `std::unordered_map` is a faster container for accessing individual elements.

The only time the code loops over `bodyDefs` is for [removing all the shapes](https://github.com/CodeAndWeb/PhysicsEditor-Loaders/blob/master/cocos2d-x/PhysicsShapeCache.cpp#L264-L267), which is where we are shifting the performance hit to since the `std::unordered_map` container is slower in that case.

I'd rather have faster object creation by using `std::unordered_map` than faster object removal by using `std::map`.
