### PR TITLE
Fix in PhysicsShapeCache for using with libGDX 1.9.8+

### DIFF
--- a/gdx-pe-loader/build.gradle
+++ b/gdx-pe-loader/build.gradle
@@ -23,7 +23,7 @@ artifacts {
 }
 
 ext {
-    gdxVersion = '1.9.6'
+    gdxVersion = '1.9.8'
 }
 
 signing {

--- a/gdx-pe-loader/src/main/java/com/codeandweb/physicseditor/PhysicsShapeCache.java
+++ b/gdx-pe-loader/src/main/java/com/codeandweb/physicseditor/PhysicsShapeCache.java
@@ -27,9 +27,9 @@ public class PhysicsShapeCache {
       XmlReader.Element rootNode = reader.parse(file);
 
       bodyDefNode = new BodyDefNode(rootNode);
-    } catch (IOException e) {
+    } catch (SerializationException e) {
       e.printStackTrace();
-      throw new SerializationException("failed to load physics shapes XML");
+      throw new SerializationException("failed to load physics shapes XML", e);
     }
   }
 


### PR DESCRIPTION
com.badlogic.gdx.utils.XmlReader#parse(Reader reader) method does not throws IOException after 1.9.8 version, it's throws SerializationException instead. It  fails GWT compilation because gwt compilator works with sources.